### PR TITLE
Fixing issue with rollback command, where it gives a ValueError

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -87,9 +87,8 @@ def _make_tracking_http_request(url, json_data):
         # ignore issues with tracking
         pass
 
-    if pid == 0:
-        # This is the child process. Exit now.
-        sys.exit(0)
+    # This is the child process. Exit now.
+    sys.exit(0)
 
 
 def track(event_name, extra: dict = None):

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -127,36 +127,39 @@ def initiate_login():
     click.echo(url)
     click.echo()
 
-    with click_spinner.spinner():
-        while True:
+    while True:
+        with click_spinner.spinner():
             try:
                 url = 'https://stories.asyncyapp.com/github/oauth_callback'
+
                 res = requests.get(f'{url}?state={state}')
 
                 if res.text == 'null':
                     raise IOError()
 
                 res.raise_for_status()
-                if res.json().get('beta') is False:
-                    click.echo(
-                        'Hello! Asyncy is in private beta at this time.')
-                    click.echo(
-                        'We\'ve added you to our beta testers queue, '
-                        'and you should hear from us\nshortly via email'
-                        ' (which is linked to your GitHub account).'
-                    )
-                    sys.exit(1)
-
-                write(res.text, f'{home}/.config')
-                init()
-                break
             except IOError:
                 time.sleep(0.5)
                 # just try again
-                pass
+                continue
             except KeyboardInterrupt:
                 click.echo('Login failed. Please try again.')
                 sys.exit(1)
+
+        if res.json().get('beta') is False:
+            click.echo(
+                'Hello! Asyncy is in private beta at this time.')
+            click.echo(
+                'We\'ve added you to our beta testers queue, '
+                'and you should hear from us\nshortly via email'
+                ' (which is linked to your GitHub account).'
+            )
+            sys.exit(1)
+
+        write(res.text, f'{home}/.config')
+        init()
+        break
+
     click.echo(
         emoji.emojize(':waving_hand:') +
         f'  Welcome {data["name"]}!'

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -182,27 +182,25 @@ def initiate_login():
                     raise IOError()
 
                 res.raise_for_status()
+                break
             except IOError:
                 time.sleep(0.5)
-                # just try again
-                continue
             except KeyboardInterrupt:
                 click.echo('Login failed. Please try again.')
                 sys.exit(1)
 
-        if res.json().get('beta') is False:
-            click.echo(
-                'Hello! Asyncy is in private beta at this time.')
-            click.echo(
-                'We\'ve added you to our beta testers queue, '
-                'and you should hear from us\nshortly via email'
-                ' (which is linked to your GitHub account).'
-            )
-            sys.exit(1)
+    if res.json().get('beta') is False:
+        click.echo(
+            'Hello! Asyncy is in private beta at this time.')
+        click.echo(
+            'We\'ve added you to our beta testers queue, '
+            'and you should hear from us\nshortly via email'
+            ' (which is linked to your GitHub account).'
+        )
+        sys.exit(1)
 
-        write(res.text, f'{home}/.config')
-        init()
-        break
+    write(res.text, f'{home}/.config')
+    init()
 
     click.echo(
         emoji.emojize(':waving_hand:') +

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -64,6 +64,8 @@ def _make_tracking_http_request(url, json_data):
     but instead just exits (sys.exit(0)). This is to ensure that whatever
     needs to happen after this method is called, does not happen twice.
     """
+    if not enable_reporting:
+        return
     if sys.platform != 'linux' and sys.platform != 'darwin':
         try:
             requests.post(url, json=json_data)
@@ -76,9 +78,6 @@ def _make_tracking_http_request(url, json_data):
     pid = os.fork()
     if pid > 0:
         # This is the parent process.
-        return
-
-    if not enable_reporting:
         return
 
     try:

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -64,6 +64,15 @@ def _make_tracking_http_request(url, json_data):
     but instead just exits (sys.exit(0)). This is to ensure that whatever
     needs to happen after this method is called, does not happen twice.
     """
+    if sys.platform != 'linux' and sys.platform != 'darwin':
+        try:
+            requests.post(url, json=json_data)
+        except Exception:
+            # ignore issues with tracking
+            pass
+
+        return
+
     pid = os.fork()
     if pid > 0:
         # This is the parent process.

--- a/cli/commands/releases.py
+++ b/cli/commands/releases.py
@@ -68,6 +68,8 @@ def rollback(version, app):
 
     if version and version[0] == 'v':
         version = version[1:]
+    else:
+        version = None
 
     if not version:
         click.echo(f'Getting latest release for app {app}... ',

--- a/cli/commands/releases.py
+++ b/cli/commands/releases.py
@@ -69,7 +69,8 @@ def rollback(version, app):
     if version and version[0] == 'v':
         version = version[1:]
     else:
-        version = None
+        click.echo("Invalid version given.")
+        sys.exit(1)
 
     if not version:
         click.echo(f'Getting latest release for app {app}... ',

--- a/cli/commands/releases.py
+++ b/cli/commands/releases.py
@@ -69,7 +69,7 @@ def rollback(version, app):
     if version and version[0] == 'v':
         version = version[1:]
     else:
-        click.echo("Invalid version given.")
+        click.echo('Invalid version given.')
         sys.exit(1)
 
     if not version:


### PR DESCRIPTION
The following command with arguments gives the following traceback:

```
➜  story-test asyncy releases rollback latest
Traceback (most recent call last):
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/bin/asyncy", line 11, in <module>
    load_entry_point('asyncy==0.9.0', 'console_scripts', 'asyncy')()
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/qnafiulislam/.pyenv/versions/3.7.2/lib/python3.7/site-packages/cli/commands/releases.py", line 80, in rollback
    if int(version) == 0:
ValueError: invalid literal for int() with base 10: 'latest'
Sentry is attempting to send 1 pending error messages
Waiting up to 10 seconds
Press Ctrl-C to quit
```
So, adding a way to make sure that we can circumvent this.