### PR TITLE
Build the snap using a tar archive produced by python setup.py sdist.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,13 +107,13 @@ jobs:
           command: docker build -t story-snapcraft snap
       - run:
           name: Build sdist tar of the CLI
-          command: docker run --rm -e CIRCLE_TAG=${CIRCLE_TAG} -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && python3 setup.py sdist'
+          command: docker run --rm -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && python3 setup.py sdist'
       - run:
           name: Move the sdist to a well known file (we move this because we do not want to edit snapcraft.yaml on the fly)
           command: mv dist/story-${CIRCLE_TAG}.tar.gz dist/story.tar.gz
       - run:
           name: Build snap image
-          command: docker run --rm -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && snapcraft clean && snapcraft'
+          command: docker run --rm -e CIRCLE_TAG=${CIRCLE_TAG} -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && snapcraft clean && snapcraft'
       - run:
           name: Install the recently build snap locally
           command: sudo snap install --dangerous story_${CIRCLE_TAG}_amd64.snap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
           command: docker build -t story-snapcraft snap
       - run:
           name: Build sdist tar of the CLI
-          command: docker run --rm -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && python3 setup.py sdist'
+          command: docker run --rm -e CIRCLE_TAG=${CIRCLE_TAG} -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && python3 setup.py sdist'
       - run:
           name: Move the sdist to a well known file (we move this because we do not want to edit snapcraft.yaml on the fly)
           command: mv dist/story-${CIRCLE_TAG}.tar.gz dist/story.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,14 @@ jobs:
           name: Build snapcraft build container
           command: docker build -t story-snapcraft snap
       - run:
+          name: Build sdist tar of the CLI
+          command: docker run --rm -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && python3 setup.py sdist'
+      - run:
+          name: Move the sdist to a well known file (we move this because we do not want to edit snapcraft.yaml on the fly)
+          command: mv dist/story-${CIRCLE_TAG}.tar.gz dist/story.tar.gz
+      - run:
           name: Build snap image
-          command: docker run --rm -e CIRCLE_TAG=${CIRCLE_TAG} -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && snapcraft clean && snapcraft'
+          command: docker run --rm -v $PWD:/story story-snapcraft /bin/sh -c 'cd /story && snapcraft clean && snapcraft'
       - run:
           name: Install the recently build snap locally
           command: sudo snap install --dangerous story_${CIRCLE_TAG}_amd64.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ parts:
   story:
     plugin: python
     python-version: python3
-    source: .
+    source: dist/story.tar.gz
     stage-packages:
       - libbz2-1.0
       - libdb5.3


### PR DESCRIPTION
When the semver Python plugin runs inside of the snapcraft build root, it always seems to get the incorrect version for the CLI. For example, if tag 0.17.2 is checked out, the semver tags the package as 0.17.3.dev0.xxx.ddmmyyyy. Seb and I tried to debug this, but couldn't get this done. As a result, Seb recommended to use the sdist archive as the source of the snap build, which worked well.

