### PR TITLE
Use the project root for compiling and deploying apps.

### DIFF
--- a/story/commands/test.py
+++ b/story/commands/test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import os
 import sys
 
 import click
@@ -55,7 +56,10 @@ def compile_app(app_name_for_analytics, debug) -> dict:
 
     click.echo(click.style('Compiling Stories… ', bold=True))
 
+    old_cwd = os.getcwd()
+
     try:
+        os.chdir(utils.get_project_root_dir())
         stories = json.loads(App.compile(utils.get_project_root_dir()))
     except StoryError as e:
         click.echo('Failed to compile project:\n', err=True)
@@ -65,6 +69,8 @@ def compile_app(app_name_for_analytics, debug) -> dict:
         click.echo('Failed to compile project:\n', err=True)
         click.echo(click.style(str(e), fg='red'), err=True)
         stories = None
+    finally:
+        os.chdir(old_cwd)
 
     result = 'Success'
     count = 0

--- a/story/commands/test.py
+++ b/story/commands/test.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import json
-import os
 import sys
 
 import click
@@ -9,7 +8,7 @@ import emoji
 
 from storyscript.exceptions import StoryError
 
-from .. import cli, options
+from .. import cli, options, utils
 
 
 @cli.cli.command()
@@ -57,7 +56,7 @@ def compile_app(app_name_for_analytics, debug) -> dict:
     click.echo(click.style('Compiling Stories… ', bold=True))
 
     try:
-        stories = json.loads(App.compile(os.getcwd()))
+        stories = json.loads(App.compile(utils.get_project_root_dir()))
     except StoryError as e:
         click.echo('Failed to compile project:\n', err=True)
         click.echo(click.style(str(e.message()), fg='red'), err=True)

--- a/story/utils.py
+++ b/story/utils.py
@@ -33,6 +33,10 @@ def get_app_name_from_yml() -> str:
         return yaml.safe_load(s).pop('app_name')
 
 
+def get_project_root_dir() -> str:
+    return os.path.dirname(find_story_yml())
+
+
 def get_asyncy_yaml(must_exist=True) -> dict:
     file = find_story_yml()
 


### PR DESCRIPTION
If story deploy is executed in a nested directory in the project root, then only the stories in the current directory are compiled and deployed. Instead, it should consider all stories starting from the project root.

Closes #169

