### PR TITLE
Brew: don't create special release branch

### DIFF
--- a/scripts/update_brew.sh
+++ b/scripts/update_brew.sh
@@ -42,11 +42,7 @@ echo "Testing the formula locally with brew..."
 brew install Formula/story.rb
 story --version | grep $tag
 story --help
-git checkout -b release_$tag
 git commit -a -m "Release $tag."
-git push origin release_$tag
-git checkout master
-git merge release_$tag
 git tag $tag
 git push origin master
 git push origin master --tags


### PR DESCRIPTION
See e.g. https://github.com/storyscript/cli/commit/3dc3de551724ee807bdcf1b26d81405c598573bc

This looks like a relict from the times where the CLI created a PR. It no longer does this, so there's no need to create all these version branches if you tag them too.