### PR TITLE
Rename main.py to __main__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,6 @@ setup(
     tests_require=test_requirements,
     extras_require={},
     requires_python='>=3.6.0',
-    entry_points={'console_scripts': ['story=story.main:cli']},
+    entry_points={'console_scripts': ['story=story.__main__:cli']},
     cmdclass={'install': Install, 'test': PyTest, 'format': Format},
 )

--- a/story/__main__.py
+++ b/story/__main__.py
@@ -6,7 +6,6 @@ try:
     from .cli import cli
 
     # Import commands for CLI.
-
     from .commands import *  # noqa
 
 except KeyboardInterrupt:


### PR DESCRIPTION
This pull request renames `main.py` to `__main__.py` allowing user to run the application as a python module.
Fixes #297 