### PR TITLE
303 Test cli as module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner, Result
@@ -137,9 +138,14 @@ def app_dir():
 
 
 @pytest.fixture
-def spawn_process():
-    def cb(cmd):
-        proc = subprocess.Popen(cmd,
+def spawn_cli_subprocess():
+    def cb(args=None):
+        # Python exec path on Windows should be quoted in case of spaces
+        path = '"{}"' if sys.platform == 'win32' else '{}'
+        python = path.format(sys.executable)
+        command = [python, '-m', 'story'] + (args or [])
+
+        proc = subprocess.Popen(command,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner, Result
@@ -133,3 +134,16 @@ def init_sample_app_in_cwd():
 @pytest.fixture
 def app_dir():
     pass
+
+
+@pytest.fixture
+def spawn_process():
+    def cb(cmd):
+        proc = subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+
+        return proc.returncode, stdout.decode(), stderr.decode()
+
+    return cb

--- a/tests/integration/cli.py
+++ b/tests/integration/cli.py
@@ -6,14 +6,14 @@ from story.cli import cli
 
 def test_cli_as_module(spawn_process):
     # We don't need space-indents from docstrings
-    output = str(cli.__doc__).replace("  ", " ").strip()
+    output = str(cli.__doc__).replace('  ', ' ').strip()
 
     # Python executable path on Windows should be quoted
-    path = '"{}"' if sys.platform == "win32" else "{}"
+    path = '"{}"' if sys.platform == 'win32' else '{}'
     python = path.format(sys.executable)
 
-    exit_code, stdout, stderr = spawn_process([python, "-m", "story"])
+    exit_code, stdout, stderr = spawn_process([python, '-m', 'story'])
 
     assert exit_code == 0
     assert output in stdout
-    assert "" in stderr
+    assert '' in stderr

--- a/tests/integration/cli.py
+++ b/tests/integration/cli.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import sys
+
+from story.cli import cli
+
+
+def test_cli_as_module(spawn_process):
+    # We don't need space-indents from docstrings
+    output = str(cli.__doc__).replace("  ", " ").strip()
+
+    # Python executable path on Windows should be quoted
+    path = '"{}"' if sys.platform == "win32" else "{}"
+    python = path.format(sys.executable)
+
+    exit_code, stdout, stderr = spawn_process([python, "-m", "story"])
+
+    assert exit_code == 0
+    assert output in stdout
+    assert "" in stderr

--- a/tests/integration/cli.py
+++ b/tests/integration/cli.py
@@ -4,16 +4,11 @@ import sys
 from story.cli import cli
 
 
-def test_cli_as_module(spawn_process):
+def test_cli_as_module(spawn_cli_subprocess):
     # We don't need space-indents from docstrings
     output = str(cli.__doc__).replace('  ', ' ').strip()
-
-    # Python executable path on Windows should be quoted
-    path = '"{}"' if sys.platform == 'win32' else '{}'
-    python = path.format(sys.executable)
-
-    exit_code, stdout, stderr = spawn_process([python, '-m', 'story'])
+    exit_code, stdout, stderr = spawn_cli_subprocess()
 
     assert exit_code == 0
     assert output in stdout
-    assert '' in stderr
+    assert stderr == ''


### PR DESCRIPTION
This PR adds single test which checks if `cli` runs correctly as a python module.
Closes #303 