### PR TITLE
tox.ini(chore): Explicitly set TOXENV

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ deps =
 
 [testenv:py37]
 passenv = STORYSCRIPT_INT_CONF_ACCESS_TOKEN STORYSCRIPT_INT_CONF_USER_ID
+setenv =
+    TOXENV={envname}
 commands =
     pytest --cov=. --cov-config=.coveragerc --cov-report=term-missing {posargs}
     coverage xml


### PR DESCRIPTION
The cli code detects tox via TOXENV environment variable.
However tox will only pass it to pytest if it is explicitly set.

Related to https://github.com/storyscript/cli/issues/288

